### PR TITLE
Only attempt to access `classes` attribute on elements that have it

### DIFF
--- a/noteout/write_notebooks.py
+++ b/noteout/write_notebooks.py
@@ -56,7 +56,7 @@ def finalize(doc):
 
 
 def filter_out(elem):
-    return [e for e in elem.content if 'cell-code' in e.classes]
+    return [e for e in elem.content if 'cell-code' in getattr(e, 'classes', {})]
 
 
 def strip_cells(elem, doc):


### PR DESCRIPTION
Fixes build with latest Quarto.